### PR TITLE
Add mobile-friendly navigation and restore src files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # RepSmasher
+
 Personal Work Out application
+
+Open `index.html` in a browser on your phone or desktop. The start page displays
+large navigation buttons so you can quickly jump to pages under `src/` such as
+creating or choosing a workout.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RepSmasher - Home</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>RepSmasher</h1>
+    <div class="nav-buttons">
+      <a href="src/create.html" class="btn">Create Workout</a>
+      <a href="src/choose.html" class="btn">Choose Workout</a>
+      <a href="src/workout.html" class="btn">Start Workout</a>
+      <a href="src/summary.html" class="btn">Workout Summary</a>
+    </div>
+  </div>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,8 @@
+const counterElement = document.getElementById('counter');
+const button = document.getElementById('repButton');
+let count = 0;
+
+button.addEventListener('click', () => {
+  count += 1;
+  counterElement.textContent = count.toString();
+});

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,42 @@
+// Utility functions for storage
+function load(key, def) {
+    const data = localStorage.getItem(key);
+    return data ? JSON.parse(data) : def;
+}
+function save(key, val) {
+    localStorage.setItem(key, JSON.stringify(val));
+}
+
+// Data structures
+let routines = load('routines', []);
+let workouts = load('workouts', []);
+
+function createId() {
+    return Date.now().toString(36) + Math.random().toString(36).substr(2, 5);
+}
+
+function updateStats() {
+    const totalWorkouts = workouts.length;
+    const totalSets = workouts.reduce((a, w) => a + w.records.length, 0);
+    const totalWeight = workouts.reduce((a, w) => a + w.records.reduce((b, r) => b + (r.weight*r.reps),0), 0);
+
+    const statsEl = document.getElementById('stats');
+    if (statsEl) {
+        statsEl.innerHTML = `<p>Total Workouts: ${totalWorkouts}</p>` +
+            `<p>Total Sets: ${totalSets}</p>` +
+            `<p>Total Weight: ${totalWeight}</p>`;
+    }
+}
+
+function saveRoutine(routine) {
+    const idx = routines.findIndex(r => r.id === routine.id);
+    if (idx >= 0) routines[idx] = routine; else routines.push(routine);
+    save('routines', routines);
+}
+
+function addWorkoutLog(log) {
+    workouts.push(log);
+    save('workouts', workouts);
+}
+
+updateStats();

--- a/src/choose.html
+++ b/src/choose.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Choose Workout</title>
+    <link rel="stylesheet" href="style.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body>
+<header>
+    <h1>Choose Workout</h1>
+    <div class="nav-buttons">
+        <a href="../index.html" class="btn">Home</a>
+        <a href="create.html" class="btn">Create Workout</a>
+        <a href="choose.html" class="btn">Choose Workout</a>
+    </div>
+</header>
+<div class="container">
+    <ul id="routineList" class="list"></ul>
+</div>
+<script src="app.js"></script>
+<script>
+function renderRoutines() {
+    const list = document.getElementById('routineList');
+    list.innerHTML = '';
+    routines.forEach(r => {
+        const li = document.createElement('li');
+        li.textContent = r.name;
+        li.onclick = () => {
+            window.location.href = `workout.html?id=${r.id}`;
+        };
+        list.appendChild(li);
+    });
+}
+
+renderRoutines();
+</script>
+</body>
+</html>

--- a/src/create.html
+++ b/src/create.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Create Workout</title>
+    <link rel="stylesheet" href="style.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body>
+<header>
+    <h1>Create Workout</h1>
+    <div class="nav-buttons">
+        <a href="../index.html" class="btn">Home</a>
+        <a href="create.html" class="btn">Create Workout</a>
+        <a href="choose.html" class="btn">Choose Workout</a>
+    </div>
+</header>
+<div class="container">
+    <label>Name: <input type="text" id="routineName"></label>
+    <button id="addExercise">Add Exercise</button>
+    <ul id="exerciseList" class="list"></ul>
+    <button id="saveRoutine">Save Routine</button>
+</div>
+<script src="app.js"></script>
+<script>
+let exercises = [];
+
+function renderList() {
+    const list = document.getElementById('exerciseList');
+    list.innerHTML = '';
+    exercises.forEach((ex, idx) => {
+        const li = document.createElement('li');
+        li.draggable = true;
+        li.dataset.idx = idx;
+        li.innerHTML = `${ex.type} - ${ex.sets}x${ex.reps} @ ${ex.weight}kg - rest ${ex.rest}s`;
+        li.addEventListener('dragstart', drag);
+        li.addEventListener('dragover', allowDrop);
+        li.addEventListener('drop', drop);
+        list.appendChild(li);
+    });
+}
+
+function drag(ev) { ev.dataTransfer.setData('text', ev.target.dataset.idx); }
+function allowDrop(ev) { ev.preventDefault(); }
+function drop(ev) {
+    ev.preventDefault();
+    const from = +ev.dataTransfer.getData('text');
+    const to = +ev.target.dataset.idx;
+    const item = exercises.splice(from, 1)[0];
+    exercises.splice(to, 0, item);
+    renderList();
+}
+
+document.getElementById('addExercise').onclick = () => {
+    const type = prompt('Exercise name');
+    const sets = parseInt(prompt('Sets'),10) || 1;
+    const reps = parseInt(prompt('Reps'),10) || 1;
+    const weight = parseFloat(prompt('Weight (kg)'),10) || 0;
+    const rest = parseInt(prompt('Rest seconds'),10) || 0;
+    if (type) {
+        exercises.push({type, sets, reps, weight, rest});
+        renderList();
+    }
+};
+
+document.getElementById('saveRoutine').onclick = () => {
+    const name = document.getElementById('routineName').value || 'Routine';
+    const routine = {id:createId(), name, exercises};
+    saveRoutine(routine);
+    window.location.href = 'index.html';
+};
+
+renderList();
+</script>
+</body>
+</html>

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>RepSmasher - Home</title>
+    <link rel="stylesheet" href="style.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body>
+<header>
+    <h1>RepSmasher</h1>
+    <div class="nav-buttons">
+        <a href="../index.html" class="btn">Home</a>
+        <a href="create.html" class="btn">Create Workout</a>
+        <a href="choose.html" class="btn">Choose Workout</a>
+    </div>
+</header>
+<div class="container">
+    <h2>Statistics</h2>
+    <div id="stats" class="stats"></div>
+    <p>Welcome to RepSmasher! Track your workouts and smash those goals.</p>
+</div>
+<script src="app.js"></script>
+</body>
+</html>

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,63 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    background: #333;
+    color: white;
+    padding: 10px;
+}
+
+nav a {
+    margin-right: 10px;
+    color: white;
+}
+
+.container {
+    padding: 15px;
+}
+
+button {
+    padding: 5px 10px;
+    margin: 5px 0;
+}
+
+.list {
+    list-style: none;
+    padding: 0;
+}
+
+.list li {
+    padding: 5px;
+    background: #f0f0f0;
+    margin-bottom: 5px;
+    cursor: move;
+}
+
+.stats {
+    margin-bottom: 15px;
+}
+
+.nav-buttons {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.btn {
+    display: block;
+    width: 100%;
+    background-color: #007bff;
+    color: #fff;
+    text-decoration: none;
+    padding: 15px;
+    font-size: 1.2em;
+    text-align: center;
+    border-radius: 8px;
+}
+
+.btn:hover {
+    background-color: #0056b3;
+}

--- a/src/summary.html
+++ b/src/summary.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Workout Summary</title>
+    <link rel="stylesheet" href="style.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body>
+<header>
+    <h1>Workout Summary</h1>
+    <div class="nav-buttons">
+        <a href="../index.html" class="btn">Home</a>
+        <a href="create.html" class="btn">Create Workout</a>
+        <a href="choose.html" class="btn">Choose Workout</a>
+    </div>
+</header>
+<div class="container">
+    <div id="summary"></div>
+    <button onclick="window.location.href='index.html'">Back Home</button>
+</div>
+<script src="app.js"></script>
+<script>
+const last = workouts[workouts.length-1];
+const summaryEl = document.getElementById('summary');
+if (last) {
+    const routine = routines.find(r=>r.id===last.routineId) || {name:'Workout'};
+    summaryEl.innerHTML = `<h2>${routine.name}</h2>` +
+        `<p>Total time: ${(last.totalTime/1000).toFixed(1)}s</p>` +
+        last.records.map(r=> `<div>${r.type}: ${r.reps} reps @ ${r.weight}kg </div>`).join('');
+}
+updateStats();
+</script>
+</body>
+</html>

--- a/src/workout.html
+++ b/src/workout.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Workout</title>
+    <link rel="stylesheet" href="style.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+</head>
+<body>
+<header>
+    <h1>Workout</h1>
+    <div class="nav-buttons">
+        <a href="../index.html" class="btn">Home</a>
+        <a href="create.html" class="btn">Create Workout</a>
+        <a href="choose.html" class="btn">Choose Workout</a>
+    </div>
+</header>
+<div class="container">
+    <h2 id="routineTitle"></h2>
+    <div id="currentExercise"></div>
+    <button id="doneBtn">Done</button>
+</div>
+<script src="app.js"></script>
+<script>
+const params = new URLSearchParams(location.search);
+const id = params.get('id');
+const routine = routines.find(r => r.id === id);
+const titleEl = document.getElementById('routineTitle');
+const currentEl = document.getElementById('currentExercise');
+const doneBtn = document.getElementById('doneBtn');
+
+let index = 0;
+let startTime = Date.now();
+let records = [];
+let exerciseStart = startTime;
+
+function showExercise() {
+    if (!routine || index >= routine.exercises.length) {
+        finish();
+        return;
+    }
+    const ex = routine.exercises[index];
+    titleEl.textContent = routine.name;
+    currentEl.innerHTML = `<h3>${ex.type}</h3>` +
+        `<p>Sets: ${ex.sets} Reps: <input type='number' id='reps' value='${ex.reps}'>`+
+        ` Weight: <input type='number' id='weight' value='${ex.weight}'></p>` +
+        `<p>Rest: ${ex.rest}s</p>`;
+}
+
+doneBtn.onclick = () => {
+    const reps = parseInt(document.getElementById('reps').value,10);
+    const weight = parseFloat(document.getElementById('weight').value);
+    const now = Date.now();
+    const ex = routine.exercises[index];
+    records.push({type:ex.type,reps,weight,start:exerciseStart,end:now,rest:ex.rest});
+    index++;
+    exerciseStart = Date.now();
+    if (index < routine.exercises.length) {
+        showExercise();
+    } else {
+        finish();
+    }
+};
+
+function finish() {
+    const totalTime = Date.now() - startTime;
+    addWorkoutLog({routineId:routine.id,date:new Date().toISOString(),records,totalTime});
+    window.location.href = 'summary.html';
+}
+
+showExercise();
+</script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,31 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  padding: 20px;
+}
+
+.nav-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.btn {
+  display: block;
+  width: 100%;
+  background-color: #007bff;
+  color: #fff;
+  text-decoration: none;
+  padding: 15px;
+  font-size: 1.2em;
+  text-align: center;
+  border-radius: 8px;
+}
+
+.btn:hover {
+  background-color: #0056b3;
+}


### PR DESCRIPTION
## Summary
- restore original `src` directory with app pages
- delete obsolete placeholder `create.html`
- update index page with phone-friendly navigation buttons to each section
- add matching button styles in `src/style.css`
- update README with brief usage instructions

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6877dadecd8c832c9049439f61b6cde5