### PR TITLE
Enable rest sets in workout creator

### DIFF
--- a/src/create.html
+++ b/src/create.html
@@ -17,7 +17,20 @@
 </header>
 <div class="container">
     <label>Name: <input type="text" id="routineName"></label>
-    <button id="addExercise">Add Exercise</button>
+
+    <div class="inputs">
+        <input type="text" id="exName" placeholder="Exercise name">
+        <input type="number" id="exReps" placeholder="Reps" min="0">
+        <input type="number" id="exWeight" placeholder="Weight" min="0" step="0.1">
+        <input type="number" id="exSets" placeholder="Sets" min="1" value="1">
+        <button id="addExercise">Add Exercise</button>
+    </div>
+
+    <div class="inputs">
+        <input type="number" id="restSeconds" placeholder="Rest seconds" min="0" value="30">
+        <button id="addRest">Add Rest Set</button>
+    </div>
+
     <ul id="exerciseList" class="list"></ul>
     <button id="saveRoutine">Save Routine</button>
 </div>
@@ -32,7 +45,11 @@ function renderList() {
         const li = document.createElement('li');
         li.draggable = true;
         li.dataset.idx = idx;
-        li.innerHTML = `${ex.type} - ${ex.sets}x${ex.reps} @ ${ex.weight}kg - rest ${ex.rest}s`;
+        if (ex.restSet) {
+            li.textContent = `Rest - ${ex.rest}s`;
+        } else {
+            li.textContent = `${ex.type} - ${ex.sets}x${ex.reps} @ ${ex.weight}kg`;
+        }
         li.addEventListener('dragstart', drag);
         li.addEventListener('dragover', allowDrop);
         li.addEventListener('drop', drop);
@@ -52,15 +69,24 @@ function drop(ev) {
 }
 
 document.getElementById('addExercise').onclick = () => {
-    const type = prompt('Exercise name');
-    const sets = parseInt(prompt('Sets'),10) || 1;
-    const reps = parseInt(prompt('Reps'),10) || 1;
-    const weight = parseFloat(prompt('Weight (kg)'),10) || 0;
-    const rest = parseInt(prompt('Rest seconds'),10) || 0;
+    const type = document.getElementById('exName').value.trim();
+    const reps = parseInt(document.getElementById('exReps').value, 10) || 0;
+    const weight = parseFloat(document.getElementById('exWeight').value) || 0;
+    const sets = parseInt(document.getElementById('exSets').value, 10) || 1;
     if (type) {
-        exercises.push({type, sets, reps, weight, rest});
+        exercises.push({type, sets, reps, weight, rest:0});
+        document.getElementById('exName').value = '';
+        document.getElementById('exReps').value = '';
+        document.getElementById('exWeight').value = '';
+        document.getElementById('exSets').value = '1';
         renderList();
     }
+};
+
+document.getElementById('addRest').onclick = () => {
+    const rest = parseInt(document.getElementById('restSeconds').value,10) || 0;
+    exercises.push({type:'Rest', sets:1, reps:0, weight:0, rest, restSet:true});
+    renderList();
 };
 
 document.getElementById('saveRoutine').onclick = () => {

--- a/src/style.css
+++ b/src/style.css
@@ -36,6 +36,15 @@ button {
     cursor: move;
 }
 
+.inputs {
+    margin: 10px 0;
+}
+
+.inputs input {
+    margin-right: 5px;
+    padding: 5px;
+}
+
 .stats {
     margin-bottom: 15px;
 }

--- a/src/workout.html
+++ b/src/workout.html
@@ -41,17 +41,26 @@ function showExercise() {
     }
     const ex = routine.exercises[index];
     titleEl.textContent = routine.name;
-    currentEl.innerHTML = `<h3>${ex.type}</h3>` +
-        `<p>Sets: ${ex.sets} Reps: <input type='number' id='reps' value='${ex.reps}'>`+
-        ` Weight: <input type='number' id='weight' value='${ex.weight}'></p>` +
-        `<p>Rest: ${ex.rest}s</p>`;
+    if (ex.restSet) {
+        currentEl.innerHTML = `<h3>Rest</h3><p>Rest for ${ex.rest}s</p>`;
+        doneBtn.textContent = 'Next';
+    } else {
+        currentEl.innerHTML = `<h3>${ex.type}</h3>` +
+            `<p>Sets: ${ex.sets} Reps: <input type='number' id='reps' value='${ex.reps}'>`+
+            ` Weight: <input type='number' id='weight' value='${ex.weight}'></p>`;
+        doneBtn.textContent = 'Done';
+    }
 }
 
 doneBtn.onclick = () => {
-    const reps = parseInt(document.getElementById('reps').value,10);
-    const weight = parseFloat(document.getElementById('weight').value);
-    const now = Date.now();
     const ex = routine.exercises[index];
+    let reps = 0;
+    let weight = 0;
+    if (!ex.restSet) {
+        reps = parseInt(document.getElementById('reps').value,10);
+        weight = parseFloat(document.getElementById('weight').value);
+    }
+    const now = Date.now();
     records.push({type:ex.type,reps,weight,start:exerciseStart,end:now,rest:ex.rest});
     index++;
     exerciseStart = Date.now();


### PR DESCRIPTION
## Summary
- allow creating exercises without prompts
- add controls to insert rest sets
- show rest sets correctly during workout
- style input rows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687837b78a7c832cba5411d03693ea0e