### PR TITLE
Fix rest summary display

### DIFF
--- a/src/summary.html
+++ b/src/summary.html
@@ -27,7 +27,12 @@ if (last) {
     const routine = routines.find(r=>r.id===last.routineId) || {name:'Workout'};
     summaryEl.innerHTML = `<h2>${routine.name}</h2>` +
         `<p>Total time: ${(last.totalTime/1000).toFixed(1)}s</p>` +
-        last.records.map(r=> `<div>${r.type}: ${r.reps} reps @ ${r.weight}kg </div>`).join('');
+        last.records.map(r => {
+            if (r.type === 'Rest') {
+                return `<div>Rest: ${r.rest}s</div>`;
+            }
+            return `<div>${r.type}: ${r.reps} reps @ ${r.weight}kg </div>`;
+        }).join('');
 }
 updateStats();
 </script>


### PR DESCRIPTION
## Summary
- show the duration for rest sets on summary view

## Testing
- `npx --version`

------
https://chatgpt.com/codex/tasks/task_e_6878426119bc832c9509e77ec6e4ca46