### PR TITLE
Fix rest summary display

### DIFF
--- a/src/summary.html
+++ b/src/summary.html
@@ -27,7 +27,13 @@ if (last) {
     const routine = routines.find(r=>r.id===last.routineId) || {name:'Workout'};
     summaryEl.innerHTML = `<h2>${routine.name}</h2>` +
         `<p>Total time: ${(last.totalTime/1000).toFixed(1)}s</p>` +
-        last.records.map(r=> `<div>${r.type}: ${r.reps} reps @ ${r.weight}kg </div>`).join('');
+        last.records.map(r => {
+            if (r.type === 'Rest') {
+                const secs = ((r.end - r.start) / 1000).toFixed(0);
+                return `<div>Rest: ${secs}s</div>`;
+            }
+            return `<div>${r.type}: ${r.reps} reps @ ${r.weight}kg </div>`;
+        }).join('');
 }
 updateStats();
 </script>


### PR DESCRIPTION
## Summary
- show the actual rest duration in the summary view

## Testing
- `npx --version`


------
https://chatgpt.com/codex/tasks/task_e_6878426119bc832c9509e77ec6e4ca46