### PR TITLE
Add exercise editing controls

### DIFF
--- a/src/create.html
+++ b/src/create.html
@@ -85,11 +85,28 @@ function renderList() {
         const li = document.createElement('li');
         li.draggable = true;
         li.dataset.idx = idx;
+        const span = document.createElement('span');
         if (ex.restSet) {
-            li.textContent = `Rest - ${ex.rest}s`;
+            span.textContent = `Rest - ${ex.rest}s`;
         } else {
-            li.textContent = `${ex.type} - ${ex.sets}x${ex.reps} @ ${ex.weight}kg`;
+            span.textContent = `${ex.type} - ${ex.sets}x${ex.reps} @ ${ex.weight}kg`;
         }
+        li.appendChild(span);
+
+        const dupBtn = document.createElement('button');
+        dupBtn.textContent = 'Duplicate';
+        dupBtn.onclick = (ev) => { ev.stopPropagation(); duplicateExercise(idx); };
+        li.appendChild(dupBtn);
+
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.onclick = (ev) => { ev.stopPropagation(); editExercise(idx); };
+        li.appendChild(editBtn);
+
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Delete';
+        delBtn.onclick = (ev) => { ev.stopPropagation(); deleteExercise(idx); };
+        li.appendChild(delBtn);
         li.addEventListener('dragstart', drag);
         li.addEventListener('dragover', allowDrop);
         li.addEventListener('drop', drop);
@@ -105,6 +122,41 @@ function drop(ev) {
     const to = +ev.target.dataset.idx;
     const item = exercises.splice(from, 1)[0];
     exercises.splice(to, 0, item);
+    renderList();
+}
+
+function duplicateExercise(idx) {
+    const copy = JSON.parse(JSON.stringify(exercises[idx]));
+    exercises.splice(idx + 1, 0, copy);
+    renderList();
+}
+
+function editExercise(idx) {
+    const ex = exercises[idx];
+    if (ex.restSet) {
+        const rest = prompt('Rest seconds:', ex.rest);
+        if (rest !== null) {
+            ex.rest = parseInt(rest, 10) || 0;
+        }
+    } else {
+        let type = prompt('Exercise name:', ex.type);
+        if (type === null) return;
+        const sets = prompt('Sets:', ex.sets);
+        if (sets === null) return;
+        const reps = prompt('Reps:', ex.reps);
+        if (reps === null) return;
+        const weight = prompt('Weight:', ex.weight);
+        if (weight === null) return;
+        ex.type = type.trim() || ex.type;
+        ex.sets = parseInt(sets, 10) || 1;
+        ex.reps = parseInt(reps, 10) || 0;
+        ex.weight = parseFloat(weight) || 0;
+    }
+    renderList();
+}
+
+function deleteExercise(idx) {
+    exercises.splice(idx, 1);
     renderList();
 }
 


### PR DESCRIPTION
## Summary
- add edit, duplicate, and delete buttons for exercises in the workout creator
- implement functions to edit, duplicate, and delete exercises

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6878ed7a042c832ca6a2250437ef8fba