### PR TITLE
Improve workout page layout

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -120,3 +120,11 @@ button {
     flex-direction: column;
     gap: 5px;
 }
+
+#routineTitle {
+    margin-top: 20px;
+}
+
+.exercise-name {
+    margin: 0;
+}

--- a/src/workout.html
+++ b/src/workout.html
@@ -16,11 +16,11 @@
     </nav>
 </header>
     <div class="container">
+        <h2 id="routineTitle"></h2>
         <div class="timer-wrapper">
             <span id="workoutTimer" class="timer">0:00</span>
             <button id="startBtn">Start Workout</button>
         </div>
-        <h2 id="routineTitle"></h2>
         <div id="currentExercise"></div>
         <button id="doneBtn" class="hidden">Done</button>
         <div id="progressContainer">
@@ -78,7 +78,7 @@ function showExercise() {
         }, 1000);
     } else {
         currentEl.innerHTML = `<div class="exercise-details">` +
-            `<div class="name">${ex.type}</div>` +
+            `<h3 class="exercise-name">${ex.type}</h3>` +
             `<div class="set">Set: ${ex.sets}</div>` +
             `<label>Reps: <input type='number' id='reps' value='${ex.reps}'></label>` +
             `<label>Weight: <input type='number' id='weight' value='${ex.weight}'></label>` +


### PR DESCRIPTION
## Summary
- place routine title above timer on workout page
- show exercise name as an h3 element
- add minimal CSS styles for routine title and exercise name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68793e2d62dc832c84705dfd2df6a981