### PR TITLE
Fix sets input default and mobile layout

### DIFF
--- a/src/create.html
+++ b/src/create.html
@@ -22,7 +22,7 @@
         <input type="text" id="exName" placeholder="Exercise name">
         <input type="number" id="exReps" placeholder="Reps" min="0">
         <input type="number" id="exWeight" placeholder="Weight" min="0" step="0.1">
-        <input type="number" id="exSets" placeholder="Sets" min="1" value="1">
+        <input type="number" id="exSets" placeholder="Sets" min="1">
         <button id="addExercise">Add Exercise</button>
     </div>
 
@@ -53,9 +53,6 @@ function updateToggle() {
         exInputs.style.display = 'block';
         restInputs.style.display = 'none';
         toggleBtn.textContent = 'Switch to Rest';
-        if (!document.getElementById('exSets').value) {
-            document.getElementById('exSets').value = '1';
-        }
     } else {
         exInputs.style.display = 'none';
         restInputs.style.display = 'block';
@@ -170,7 +167,7 @@ document.getElementById('addExercise').onclick = () => {
         document.getElementById('exName').value = '';
         document.getElementById('exReps').value = '';
         document.getElementById('exWeight').value = '';
-        document.getElementById('exSets').value = '1';
+        document.getElementById('exSets').value = '';
         renderList();
     }
 };

--- a/src/style.css
+++ b/src/style.css
@@ -49,11 +49,16 @@ button {
 
 .inputs {
     margin: 10px 0;
+    display: flex;
+    flex-direction: column;
 }
 
-.inputs input {
-    margin-right: 5px;
+.inputs input,
+.inputs button {
+    margin: 5px 0;
     padding: 5px;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .stats {

--- a/src/summary.html
+++ b/src/summary.html
@@ -36,7 +36,8 @@ if (last) {
                 const actual = Math.round((r.end - r.start)/1000);
                 return `<div>Rest: ${actual}s</div>`;
             }
-            return `<div>${r.type}: ${r.reps} reps @ ${r.weight}kg </div>`;
+            const setInfo = r.set ? `Set ${r.set}: ` : '';
+            return `<div>${setInfo}${r.type}: ${r.reps} reps @ ${r.weight}kg</div>`;
         }).join('');
 }
 updateStats();

--- a/src/workout.html
+++ b/src/workout.html
@@ -48,6 +48,9 @@ let index = 0;
 let startTime = null;
 let records = [];
 let exerciseStart = null;
+let currentSet = 1;
+let completedSteps = 0;
+const totalSteps = routine ? routine.exercises.reduce((sum, ex) => sum + (ex.restSet ? 1 : ex.sets), 0) : 0;
 
 function showExercise() {
     if (!routine || index >= routine.exercises.length) {
@@ -79,7 +82,7 @@ function showExercise() {
     } else {
         currentEl.innerHTML = `<div class="exercise-details">` +
             `<h3 class="exercise-name">${ex.type}</h3>` +
-            `<div class="set">Set: ${ex.sets}</div>` +
+            `<div class="set">Set ${currentSet} of ${ex.sets}</div>` +
             `<label>Reps: <input type='number' id='reps' value='${ex.reps}'></label>` +
             `<label>Weight: <input type='number' id='weight' value='${ex.weight}'></label>` +
             `</div>`;
@@ -101,13 +104,21 @@ doneBtn.onclick = () => {
         weight = parseFloat(document.getElementById('weight').value);
     }
     const now = Date.now();
-    records.push({type:ex.type,reps,weight,start:exerciseStart,end:now,rest:ex.rest});
-    index++;
-    exerciseStart = Date.now();
-    if (index < routine.exercises.length) {
+    records.push({type:ex.type,reps,weight,start:exerciseStart,end:now,rest:ex.rest,set:ex.restSet ? 1 : currentSet});
+    completedSteps++;
+    if (!ex.restSet && currentSet < ex.sets) {
+        currentSet++;
+        exerciseStart = Date.now();
         showExercise();
     } else {
-        finish();
+        currentSet = 1;
+        index++;
+        exerciseStart = Date.now();
+        if (index < routine.exercises.length) {
+            showExercise();
+        } else {
+            finish();
+        }
     }
 };
 
@@ -134,7 +145,7 @@ function updateTimer() {
 }
 
 function updateProgress() {
-    const percent = Math.floor((index / routine.exercises.length) * 100);
+    const percent = totalSteps ? Math.floor((completedSteps / totalSteps) * 100) : 0;
     progressBar.value = percent;
     progressText.textContent = `${percent}%`;
 }


### PR DESCRIPTION
## Summary
- leave Sets blank by default when creating an exercise
- remove autofill of Sets on mode toggle
- reset Sets field to blank after adding an exercise
- stack input fields vertically for better small-screen usability
- track each set while doing a workout and show it on the summary page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a2b64aa38832c9d5550f2e241c275