### PR TITLE
Implement overall set counting

### DIFF
--- a/src/workout.html
+++ b/src/workout.html
@@ -49,6 +49,7 @@ let startTime = null;
 let records = [];
 let exerciseStart = null;
 let currentSet = 1;
+let setTotals = {};
 let completedSteps = 0;
 const totalSteps = routine ? routine.exercises.reduce((sum, ex) => sum + (ex.restSet ? 1 : ex.sets), 0) : 0;
 
@@ -80,9 +81,10 @@ function showExercise() {
             }
         }, 1000);
     } else {
+        const overallSet = (setTotals[ex.type] || 0) + 1;
         currentEl.innerHTML = `<div class="exercise-details">` +
             `<h3 class="exercise-name">${ex.type}</h3>` +
-            `<div class="set">Set ${currentSet} of ${ex.sets}</div>` +
+            `<div class="set">Set ${overallSet} (${currentSet} of ${ex.sets})</div>` +
             `<label>Reps: <input type='number' id='reps' value='${ex.reps}'></label>` +
             `<label>Weight: <input type='number' id='weight' value='${ex.weight}'></label>` +
             `</div>`;
@@ -104,7 +106,11 @@ doneBtn.onclick = () => {
         weight = parseFloat(document.getElementById('weight').value);
     }
     const now = Date.now();
-    records.push({type:ex.type,reps,weight,start:exerciseStart,end:now,rest:ex.rest,set:ex.restSet ? 1 : currentSet});
+    const setNum = ex.restSet ? 1 : (setTotals[ex.type] || 0) + 1;
+    records.push({type:ex.type,reps,weight,start:exerciseStart,end:now,rest:ex.rest,set:setNum});
+    if (!ex.restSet) {
+        setTotals[ex.type] = setNum;
+    }
     completedSteps++;
     if (!ex.restSet && currentSet < ex.sets) {
         currentSet++;


### PR DESCRIPTION
## Summary
- track set totals for each exercise when repeating names in a routine
- display overall set information while working out
- store the running set number in workout records

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a3ba08d98832c895b8953cd29aaed