### PR TITLE
Remove sets field from workout creation

### DIFF
--- a/src/create.html
+++ b/src/create.html
@@ -22,7 +22,6 @@
         <input type="text" id="exName" placeholder="Exercise name">
         <input type="number" id="exReps" placeholder="Reps" min="0">
         <input type="number" id="exWeight" placeholder="Weight" min="0" step="0.1">
-        <input type="number" id="exSets" placeholder="Sets" min="1">
         <button id="addExercise">Add Exercise</button>
     </div>
 
@@ -138,14 +137,11 @@ function editExercise(idx) {
     } else {
         let type = prompt('Exercise name:', ex.type);
         if (type === null) return;
-        const sets = prompt('Sets:', ex.sets);
-        if (sets === null) return;
         const reps = prompt('Reps:', ex.reps);
         if (reps === null) return;
         const weight = prompt('Weight:', ex.weight);
         if (weight === null) return;
         ex.type = type.trim() || ex.type;
-        ex.sets = parseInt(sets, 10) || 1;
         ex.reps = parseInt(reps, 10) || 0;
         ex.weight = parseFloat(weight) || 0;
     }
@@ -161,13 +157,11 @@ document.getElementById('addExercise').onclick = () => {
     const type = document.getElementById('exName').value.trim();
     const reps = parseInt(document.getElementById('exReps').value, 10) || 0;
     const weight = parseFloat(document.getElementById('exWeight').value) || 0;
-    const sets = parseInt(document.getElementById('exSets').value, 10) || 1;
     if (type) {
-        exercises.push({type, sets, reps, weight, rest:0});
+        exercises.push({type, sets:1, reps, weight, rest:0});
         document.getElementById('exName').value = '';
         document.getElementById('exReps').value = '';
         document.getElementById('exWeight').value = '';
-        document.getElementById('exSets').value = '';
         renderList();
     }
 };


### PR DESCRIPTION
## Summary
- remove the `Sets` input from the workout creation page
- default new exercises to one set and drop the sets prompt when editing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a3f2d5490832ca8e73d72125647cd