### PR TITLE
Remove deprecated set tracking display

### DIFF
--- a/src/choose.html
+++ b/src/choose.html
@@ -77,7 +77,9 @@ function showPreview(r) {
         if (ex.restSet) {
             return `<li>Rest - ${ex.rest}s</li>`;
         }
-        return `<li>${ex.type} - ${ex.sets}x${ex.reps} @ ${ex.weight}kg</li>`;
+        const repsText = `${ex.reps} Rep${ex.reps === 1 ? '' : 's'}`;
+        const weightText = ex.weight > 0 ? ` @ ${ex.weight}kg` : '';
+        return `<li>${ex.type} - ${repsText}${weightText}</li>`;
     }).join('');
     previewModal.classList.remove('hidden');
 }

--- a/src/create.html
+++ b/src/create.html
@@ -85,7 +85,9 @@ function renderList() {
         if (ex.restSet) {
             span.textContent = `Rest - ${ex.rest}s`;
         } else {
-            span.textContent = `${ex.type} - ${ex.sets}x${ex.reps} @ ${ex.weight}kg`;
+            const repsText = `${ex.reps} Rep${ex.reps === 1 ? '' : 's'}`;
+            const weightText = ex.weight > 0 ? ` @ ${ex.weight}kg` : '';
+            span.textContent = `${ex.type} - ${repsText}${weightText}`;
         }
         li.appendChild(span);
 

--- a/src/summary.html
+++ b/src/summary.html
@@ -37,7 +37,8 @@ if (last) {
                 return `<div>Rest: ${actual}s</div>`;
             }
             const setInfo = r.set ? `Set ${r.set}: ` : '';
-            return `<div>${setInfo}${r.type}: ${r.reps} reps @ ${r.weight}kg</div>`;
+            const weightText = r.weight > 0 ? ` @ ${r.weight}kg` : '';
+            return `<div>${setInfo}${r.type}: ${r.reps} reps${weightText}</div>`;
         }).join('');
 }
 updateStats();

--- a/src/workout.html
+++ b/src/workout.html
@@ -84,7 +84,7 @@ function showExercise() {
         const overallSet = (setTotals[ex.type] || 0) + 1;
         currentEl.innerHTML = `<div class="exercise-details">` +
             `<h3 class="exercise-name">${ex.type}</h3>` +
-            `<div class="set">Set ${overallSet} (${currentSet} of ${ex.sets})</div>` +
+            `<div class="set">Set ${overallSet}</div>` +
             `<label>Reps: <input type='number' id='reps' value='${ex.reps}'></label>` +
             `<label>Weight: <input type='number' id='weight' value='${ex.weight}'></label>` +
             `</div>`;


### PR DESCRIPTION
## Summary
- simplify set display on workout screen
- make exercise preview clearer when creating/choosing workouts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a415f0234832ca59a2492c97c2a7d