### PR TITLE
Enable GH Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,6 @@ The project uses the `gh-pages` branch for deployment. Build and publish with:
 npm run deploy
 ```
 
-Your site will be available at `https://<your-username>.github.io/RepSmasher/`.
+This command runs the build for you and publishes the contents of `dist/` to the
+`gh-pages` branch. Your site will be available at
+`https://<your-username>.github.io/RepSmasher/`.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "repsmasher",
   "version": "2.0.0",
+  "homepage": "https://your-username.github.io/RepSmasher/",
   "description": "Personal Work Out application",
   "private": true,
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --host",
+    "predeploy": "npm run build",
     "deploy": "gh-pages -d dist",
     "test": "echo \"All tests passed\""
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/RepSmasher/',
   plugins: [react()],
   server: {
     host: true


### PR DESCRIPTION
## Summary
- configure Vite to use `/RepSmasher/` as the base URL
- add `predeploy` script and homepage URL for GitHub Pages
- clarify deploy instructions in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bff4d8c94832c8acddb01e6d8b5aa