### PR TITLE
Specify remote for gh-pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ npm run deploy
 ```
 
 This command runs the build for you and publishes the contents of `dist/` to the
-`gh-pages` branch. Your site will be available at
-`https://joshbrodeur.github.io/RepSmasher/`.
+`gh-pages` branch of `https://github.com/joshbrodeur/RepSmasher.git`. The site
+will be available at `https://joshbrodeur.github.io/RepSmasher/`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "preview": "vite preview --host",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist",
+    "deploy": "gh-pages -d dist -r https://github.com/joshbrodeur/RepSmasher.git",
     "test": "echo \"All tests passed\""
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- configure deploy script with explicit GitHub repo URL for gh-pages publishing
- document deployment location in README

## Testing
- `npm test`
- `npm run build`
- `npm run deploy` *(fails: unable to access 'https://github.com/joshbrodeur/RepSmasher.git/' due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_688e2b0ddbb4832c9c27e79657820fa0