### PR TITLE
fix: derive router basename from env

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import { StoreProvider } from './store.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter basename="/RepSmasher">
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <StoreProvider>
         <App />
       </StoreProvider>


### PR DESCRIPTION
## Summary
- configure BrowserRouter to use Vite base URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e627041b4832c86ed8185667107f4