### PR TITLE
feat: improve workout builder interactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "react-beautiful-dnd": "^13.1.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/pages/CreateWorkout.jsx
+++ b/src/pages/CreateWorkout.jsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import { useStore } from '../store.jsx';
 import { createId } from '../storage.js';
 
@@ -10,56 +11,74 @@ export default function CreateWorkout() {
   const editId = searchParams.get('id');
 
   const existing = routines.find(r => r.id === editId);
+  const routineId = existing ? existing.id : createId();
   const [name, setName] = useState(existing?.name || '');
   const [exercises, setExercises] = useState(() => existing ? [...existing.exercises] : []);
-  const [dragIndex, setDragIndex] = useState(null);
+  const [saveStatus, setSaveStatus] = useState('saved');
 
   function addExercise() {
     const type = prompt('Exercise name');
     if (!type) return;
     const reps = parseInt(prompt('Reps', '10'), 10) || 0;
     const weight = parseFloat(prompt('Weight', '0')) || 0;
-    setExercises([...exercises, { type, sets:1, reps, weight, rest:0 }]);
+    setExercises([...exercises, { id: createId(), type, sets:1, reps, weight, rest:0 }]);
   }
 
   function addRest() {
     const rest = parseInt(prompt('Rest seconds', '30'), 10) || 0;
-    setExercises([...exercises, { type:'Rest', sets:1, reps:0, weight:0, rest, restSet:true }]);
+    setExercises([...exercises, { id: createId(), type:'Rest', sets:1, reps:0, weight:0, rest, restSet:true }]);
+  }
+
+  function duplicate(idx) {
+    const item = exercises[idx];
+    const copy = { ...item, id: createId() };
+    const list = [...exercises];
+    list.splice(idx + 1, 0, copy);
+    setExercises(list);
   }
 
   function remove(idx) {
+    if (!window.confirm('Delete this card?')) return;
     setExercises(exercises.filter((_, i) => i !== idx));
   }
 
-  function handleDragStart(idx) {
-    setDragIndex(idx);
-  }
-
-  function handleDragOver(e) {
-    e.preventDefault();
-  }
-
-  function handleDrop(idx) {
-    if (dragIndex === null || dragIndex === idx) return;
-    const list = [...exercises];
-    const [item] = list.splice(dragIndex, 1);
-    list.splice(idx, 0, item);
+  function handleDragEnd(result) {
+    if (!result.destination) return;
+    const list = Array.from(exercises);
+    const [item] = list.splice(result.source.index, 1);
+    list.splice(result.destination.index, 0, item);
     setExercises(list);
-    setDragIndex(null);
   }
 
   function saveRoutine() {
-    const routine = { id: existing ? existing.id : createId(), name: name || 'Routine', exercises };
-    const list = existing ? routines.map(r => r.id === routine.id ? routine : r) : [...routines, routine];
-    setRoutines(list);
-    navigate('/');
+    const routine = { id: routineId, name: name || 'Routine', exercises };
+    const list = routines.some(r => r.id === routineId)
+      ? routines.map(r => r.id === routineId ? routine : r)
+      : [...routines, routine];
+    try {
+      setRoutines(list);
+      setSaveStatus('saved');
+    } catch {
+      setSaveStatus('error');
+    }
   }
+
+  useEffect(() => {
+    setSaveStatus('saving');
+    const t = setTimeout(saveRoutine, 300);
+    return () => clearTimeout(t);
+  }, [name, exercises]);
 
   function deleteRoutine() {
     if (existing) {
       setRoutines(routines.filter(r => r.id !== existing.id));
       navigate('/');
     }
+  }
+
+  function handleDone() {
+    saveRoutine();
+    navigate('/');
   }
 
   return (
@@ -81,30 +100,55 @@ export default function CreateWorkout() {
           Add Rest
         </button>
       </div>
-      <ul className="space-y-2">
-        {exercises.map((ex, idx) => (
-          <li
-            key={idx}
-            draggable
-            onDragStart={() => handleDragStart(idx)}
-            onDragOver={handleDragOver}
-            onDrop={() => handleDrop(idx)}
-            className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow flex justify-between items-center cursor-move"
-          >
-            <span>
-              {ex.restSet
-                ? `Rest - ${ex.rest}s`
-                : `${ex.type} - ${ex.reps} reps @ ${ex.weight}`}
-            </span>
-            <button className="text-red-500" onClick={() => remove(idx)}>
-              Delete
-            </button>
-          </li>
-        ))}
-      </ul>
+      <DragDropContext onDragEnd={handleDragEnd}>
+        <Droppable droppableId="exercises">
+          {(provided) => (
+            <ul
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              className="space-y-2"
+            >
+              {exercises.map((ex, idx) => (
+                <Draggable key={ex.id} draggableId={ex.id} index={idx}>
+                  {(prov) => (
+                    <li
+                      ref={prov.innerRef}
+                      {...prov.draggableProps}
+                      {...prov.dragHandleProps}
+                      className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow flex justify-between items-center"
+                    >
+                      <span>
+                        {ex.restSet
+                          ? `Rest - ${ex.rest}s`
+                          : `${ex.type} - ${ex.reps} reps @ ${ex.weight}`}
+                      </span>
+                      <div className="flex gap-2">
+                        <button className="text-blue-500" onClick={() => duplicate(idx)}>
+                          Duplicate
+                        </button>
+                        <button className="text-red-500" onClick={() => remove(idx)}>
+                          Delete
+                        </button>
+                      </div>
+                    </li>
+                  )}
+                </Draggable>
+              ))}
+              {provided.placeholder}
+            </ul>
+          )}
+        </Droppable>
+      </DragDropContext>
+      <div className="text-sm text-center text-gray-500">
+        {saveStatus === 'saving'
+          ? 'Saving...'
+          : saveStatus === 'error'
+          ? 'Save failed'
+          : 'All changes saved'}
+      </div>
       <div className="flex gap-2">
-        <button className="flex-1 p-2 bg-green-600 text-white rounded" onClick={saveRoutine}>
-          Save
+        <button className="flex-1 p-2 bg-green-600 text-white rounded" onClick={handleDone}>
+          Done
         </button>
         {existing && (
           <button className="flex-1 p-2 bg-red-600 text-white rounded" onClick={deleteRoutine}>


### PR DESCRIPTION
## Summary
- use `react-beautiful-dnd` for ordering workout cards
- support duplicating and confirming deletion of cards
- auto-save workout changes with a status indicator

## Testing
- `npm test`
- `npm install react-beautiful-dnd@13.1.1` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e72f2d3b0832ca9857ede51b401da