### PR TITLE
feat: enhance workout builder with drag-and-drop utilities

### DIFF
--- a/src/components/ConfirmDialog.jsx
+++ b/src/components/ConfirmDialog.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function ConfirmDialog({ open, message, onConfirm, onCancel }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg w-72">
+        <p className="mb-4 text-sm text-center">{message}</p>
+        <div className="flex justify-end gap-2">
+          <button
+            className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            className="px-3 py-1 rounded bg-red-600 text-white"
+            onClick={onConfirm}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SaveWorkoutModal.jsx
+++ b/src/components/SaveWorkoutModal.jsx
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react';
+
+export default function SaveWorkoutModal({ open, initialName = '', onSave, onCancel }) {
+  const [value, setValue] = useState(initialName);
+
+  useEffect(() => {
+    if (open) setValue(initialName);
+  }, [open, initialName]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg w-80 space-y-4">
+        <h2 className="text-lg font-bold text-center">Save Workout</h2>
+        <input
+          className="w-full p-2 rounded border dark:bg-gray-700"
+          placeholder="Workout name"
+          value={value}
+          onChange={e => setValue(e.target.value)}
+        />
+        <div className="flex gap-2 justify-end">
+          <button
+            className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            className="px-3 py-1 rounded bg-green-600 text-white"
+            onClick={() => onSave(value.trim())}
+            disabled={!value.trim()}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable SaveWorkoutModal and ConfirmDialog components
- enable duplicating cards, confirmation before removal and manual save option
- introduce offline-aware auto save with status feedback

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688e7a4b2bf0832c970cfc7e094cec7f