### PR TITLE
chore: add Vitest setup and component tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview --host",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist -r https://github.com/joshbrodeur/RepSmasher.git",
-    "test": "echo \"All tests passed\""
+    "test": "vitest"
   },
   "keywords": [],
   "author": "",
@@ -28,6 +28,10 @@
     "gh-pages": "^6.1.1",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.1",
-    "vite": "^7.0.6"
+    "vite": "^7.0.6",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^14.2.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/components/BottomNavigation.test.jsx
+++ b/src/components/BottomNavigation.test.jsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import BottomNavigation from './BottomNavigation.jsx';
+import '@testing-library/jest-dom';
+
+describe('BottomNavigation', () => {
+  it('renders navigation links', () => {
+    render(
+      <MemoryRouter>
+        <BottomNavigation />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText(/Home/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Create/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Logs/i)).toBeInTheDocument();
+  });
+});

--- a/src/storage.test.js
+++ b/src/storage.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { load, save, createId } from './storage.js';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('storage utilities', () => {
+  it('loads default when key is missing', () => {
+    const result = load('missing', 'default');
+    expect(result).toBe('default');
+  });
+
+  it('saves and loads data', () => {
+    const data = { a: 1 };
+    save('key', data);
+    expect(load('key', null)).toEqual(data);
+  });
+
+  it('createId generates unique strings', () => {
+    const id1 = createId();
+    const id2 = createId();
+    expect(id1).not.toBe(id2);
+    expect(typeof id1).toBe('string');
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,5 +11,8 @@ export default defineConfig({
   preview: {
     host: true,
     allowedHosts: ['.replit.dev']
+  },
+  test: {
+    environment: 'jsdom'
   }
 });


### PR DESCRIPTION
## Summary
- set up Vitest testing framework
- add basic tests for storage utilities and navigation component
- update test script to run Vitest

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ebe40c4d8832c9541c3c4e683c42e