### PR TITLE
chore: add npm audit script and CI check

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,18 @@
+name: Dependency Audit
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run audit

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview --host",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist -r https://github.com/joshbrodeur/RepSmasher.git",
-    "test": "vitest"
+    "test": "vitest",
+    "audit": "npm audit"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `npm audit` script
- run audit in GitHub Actions to fail on vulnerabilities

## Testing
- `npm test` *(fails: expect is not defined)*
- `npm run audit` *(fails: audit endpoint returned an error)*

------
https://chatgpt.com/codex/tasks/task_e_688ec1a18514832c80151105a5020bc8