### PR TITLE
feat: add workouts tab to bottom navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,6 +42,7 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/create" element={<CreateWorkout />} />
           <Route path="/choose" element={<ChooseWorkout />} />
+          <Route path="/workouts" element={<ChooseWorkout />} />
           <Route path="/logs" element={<Logs />} />
           <Route path="/workout/:id" element={<Workout />} />
           <Route path="/summary/:index" element={<Summary />} />

--- a/src/components/BottomNavigation.jsx
+++ b/src/components/BottomNavigation.jsx
@@ -4,41 +4,104 @@ export default function BottomNavigation() {
   const { pathname } = useLocation();
 
   const items = [
-    { to: '/', label: 'Home', icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24">
-        <path d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75h-5.25a.75.75 0 01-.75-.75V13.5H9.75v7.5a.75.75 0 01-.75.75H3.75A.75.75 0 013 21V9.75z" />
-      </svg>
-    ) },
-    { to: '/create', label: 'Create', icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24">
-        <path d="M12 5v14m7-7H5" />
-      </svg>
-    ) },
-    { to: '/logs', label: 'Logs', icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24">
-        <path d="M4 6h16M4 12h16M4 18h16" />
-      </svg>
-    ) },
+    {
+      to: '/',
+      label: 'Home',
+      icon: (
+        <svg
+          className="w-5 h-5 mb-1"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          viewBox="0 0 24 24"
+        >
+          <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z" />
+          <path d="M9 22V12h6v10" />
+        </svg>
+      ),
+    },
+    {
+      to: '/create',
+      label: 'Create',
+      icon: (
+        <svg
+          className="w-5 h-5 mb-1"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          viewBox="0 0 24 24"
+        >
+          <path d="M12 5v14" />
+          <path d="M5 12h14" />
+        </svg>
+      ),
+    },
+    {
+      to: '/workouts',
+      label: 'Workouts',
+      icon: (
+        <svg
+          className="w-5 h-5 mb-1"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          viewBox="0 0 24 24"
+        >
+          <circle cx="5" cy="12" r="2" />
+          <circle cx="19" cy="12" r="2" />
+          <rect x="7" y="11" width="10" height="2" />
+        </svg>
+      ),
+    },
+    {
+      to: '/logs',
+      label: 'Logs',
+      icon: (
+        <svg
+          className="w-5 h-5 mb-1"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          viewBox="0 0 24 24"
+        >
+          <path d="M3 3v18h18" />
+          <path d="M18 17V9" />
+          <path d="M13 17V5" />
+          <path d="M8 17v-3" />
+        </svg>
+      ),
+    },
   ];
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-white/95 dark:bg-gray-900/90 backdrop-blur border-t border-gray-200 dark:border-gray-700">
-      <div className="flex justify-around items-center py-2 max-w-md mx-auto">
-        {items.map(item => (
-          <Link
-            key={item.to}
-            to={item.to}
-            className={`flex flex-col items-center gap-1 py-3 px-4 rounded-xl text-sm transition-colors ${
-              pathname === item.to
-                ? 'bg-blue-100 text-blue-600 shadow'
-                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800'
-            }`}
-            aria-label={item.label}
-          >
-            {item.icon}
-            <span className="text-xs font-medium">{item.label}</span>
-          </Link>
-        ))}
+    <div className="fixed bottom-0 left-0 right-0 bg-white/90 dark:bg-gray-900/90 backdrop-blur-md border-t border-slate-200 dark:border-slate-700 shadow-lg">
+      <div className="flex justify-around items-center py-2 px-4 max-w-md mx-auto">
+        {items.map((item) => {
+          const isActive = pathname === item.to;
+          return (
+            <Link
+              key={item.to}
+              to={item.to}
+              className={`flex flex-col items-center justify-center p-2 rounded-lg transition-all duration-200 ${
+                isActive
+                  ? 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-950'
+                  : 'text-slate-400 hover:text-slate-600 hover:bg-slate-50 dark:text-slate-500 dark:hover:text-slate-300 dark:hover:bg-slate-800'
+              }`}
+              aria-label={item.label}
+            >
+              {item.icon}
+              <span className="text-xs font-medium">{item.label}</span>
+            </Link>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/BottomNavigation.test.jsx
+++ b/src/components/BottomNavigation.test.jsx
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import BottomNavigation from './BottomNavigation.jsx';
-import '@testing-library/jest-dom';
 
 describe('BottomNavigation', () => {
   it('renders navigation links', () => {
@@ -12,8 +11,9 @@ describe('BottomNavigation', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByLabelText(/Home/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Create/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Logs/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Home/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Create/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Workouts/i)).toBeTruthy();
+    expect(screen.getByLabelText(/Logs/i)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- update bottom nav to show Home, Create, Workouts, and Logs icons
- wire new Workouts tab to `/workouts`
- adjust navigation test coverage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ec4eba12c832ca512ca6832c46250