### PR TITLE
fix: run vitest in ci mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview --host",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist -r https://github.com/joshbrodeur/RepSmasher.git",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- run vitest in non-watch mode to avoid hanging during tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ed33eaad8832ca8b54a6295198769