### PR TITLE
Improve bottom navigation accessibility

### DIFF
--- a/src/components/BottomNavigation.jsx
+++ b/src/components/BottomNavigation.jsx
@@ -1,6 +1,8 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 
 export default function BottomNavigation() {
+
+  const location = useLocation();
 
   const items = [
     {
@@ -82,25 +84,31 @@ export default function BottomNavigation() {
 
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-white/90 dark:bg-gray-900/90 backdrop-blur-md border-t border-slate-200 dark:border-slate-700 shadow-lg">
-      <div className="flex justify-around items-center py-2 px-4 max-w-md mx-auto">
-        {items.map((item) => (
-          <NavLink
-            key={item.to}
-            to={item.to}
-            className={({ isActive }) =>
-              `flex flex-col items-center justify-center p-2 rounded-lg transition-all duration-200 ${
+      <nav
+        role="navigation"
+        aria-label="Bottom navigation"
+        className="flex justify-around items-center py-2 px-4 max-w-md mx-auto"
+      >
+        {items.map((item) => {
+          const isActive = location.pathname === item.to;
+          return (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={`flex flex-col items-center justify-center p-2 rounded-lg transition-all duration-200 ${
                 isActive
                   ? 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-950'
                   : 'text-slate-400 hover:text-slate-600 hover:bg-slate-50 dark:text-slate-500 dark:hover:text-slate-300 dark:hover:bg-slate-800'
-              }`
-            }
-            aria-label={item.label}
-          >
-            {item.icon}
-            <span className="text-xs font-medium">{item.label}</span>
-          </NavLink>
-        ))}
-      </div>
+              }`}
+              aria-label={item.label}
+              aria-current={isActive ? 'page' : undefined}
+            >
+              {item.icon}
+              <span className="text-xs font-medium">{item.label}</span>
+            </NavLink>
+          );
+        })}
+      </nav>
     </div>
   );
 }

--- a/src/components/BottomNavigation.test.jsx
+++ b/src/components/BottomNavigation.test.jsx
@@ -1,7 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
 import { MemoryRouter } from 'react-router-dom';
 import BottomNavigation from './BottomNavigation.jsx';
+
+afterEach(cleanup);
 
 describe('BottomNavigation', () => {
   it('renders navigation links', () => {
@@ -15,5 +18,27 @@ describe('BottomNavigation', () => {
     expect(screen.getByLabelText(/Create/i)).toBeTruthy();
     expect(screen.getByLabelText(/Workouts/i)).toBeTruthy();
     expect(screen.getByLabelText(/Logs/i)).toBeTruthy();
+  });
+
+  it('wraps links in a nav element with accessibility attributes', () => {
+    render(
+      <MemoryRouter>
+        <BottomNavigation />
+      </MemoryRouter>
+    );
+
+    const nav = screen.getByRole('navigation', { name: /bottom navigation/i });
+    expect(nav).toBeTruthy();
+  });
+
+  it('marks the active link with aria-current', () => {
+    render(
+      <MemoryRouter initialEntries={["/create"]}>
+        <BottomNavigation />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText(/Create/i)).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByLabelText(/Home/i)).not.toHaveAttribute('aria-current');
   });
 });


### PR DESCRIPTION
## Summary
- wrap bottom navigation links in nav with ARIA label
- mark active link with aria-current
- add tests for nav landmark and active link indicator

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ed5dd9b70832c9f06d0c087a361f7