### PR TITLE
feat: add workouts page with card layout and actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home.jsx';
 import CreateWorkout from './pages/CreateWorkout.jsx';
 import ChooseWorkout from './pages/ChooseWorkout.jsx';
+import Workouts from './pages/Workouts.jsx';
 import Logs from './pages/Logs.jsx';
 import Workout from './pages/Workout.jsx';
 import Summary from './pages/Summary.jsx';
@@ -43,7 +44,7 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/create" element={<CreateWorkout />} />
           <Route path="/choose" element={<ChooseWorkout />} />
-          <Route path="/workouts" element={<ChooseWorkout />} />
+          <Route path="/workouts" element={<Workouts />} />
           <Route path="/logs" element={<Logs />} />
           <Route path="/workout/:id" element={<Workout />} />
           <Route path="/summary/:index" element={<Summary />} />

--- a/src/pages/Workouts.jsx
+++ b/src/pages/Workouts.jsx
@@ -1,0 +1,62 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useStore } from '../store.jsx';
+import { createId } from '../storage.js';
+
+export default function Workouts() {
+  const { routines, setRoutines } = useStore();
+  const navigate = useNavigate();
+
+  function remove(id) {
+    if (confirm('Delete this routine?')) {
+      setRoutines(routines.filter(r => r.id !== id));
+    }
+  }
+
+  function duplicate(id) {
+    const routine = routines.find(r => r.id === id);
+    if (!routine) return;
+    const copy = {
+      ...routine,
+      id: createId(),
+      name: routine.name + ' Copy',
+      exercises: routine.exercises.map(ex => ({ ...ex, id: createId() })),
+    };
+    setRoutines([...routines, copy]);
+  }
+
+  if (routines.length === 0) {
+    return (
+      <div className="max-w-md mx-auto text-center">
+        <p className="text-gray-500 mb-4">No workouts saved.</p>
+        <Link className="text-blue-600" to="/create">Create your first workout</Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-md mx-auto space-y-4">
+      {routines.map(r => (
+        <div
+          key={r.id}
+          className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow"
+        >
+          <div
+            className="cursor-pointer"
+            onClick={() => navigate(`/workout/${r.id}`)}
+          >
+            <h3 className="text-lg font-bold">{r.name}</h3>
+            <p className="text-sm text-gray-500">
+              {r.exercises.length} exercise{r.exercises.length !== 1 ? 's' : ''}
+            </p>
+          </div>
+          <div className="flex justify-end gap-4 mt-4 text-sm">
+            <Link className="text-blue-600" to={`/create?id=${r.id}`}>Edit</Link>
+            <button className="text-blue-600" onClick={() => duplicate(r.id)}>Duplicate</button>
+            <button className="text-red-500" onClick={() => remove(r.id)}>Delete</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- show saved workouts on dedicated Workouts page
- allow editing, duplicating, and deleting workouts
- route bottom-nav Workouts link to new page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f5d5bfea4832cacec0895570d24e3