### PR TITLE
chore: enable react router v7 flags

### DIFF
--- a/src/components/BottomNavigation.test.jsx
+++ b/src/components/BottomNavigation.test.jsx
@@ -5,12 +5,14 @@ import { MemoryRouter } from 'react-router-dom';
 import BottomNavigation from './BottomNavigation.jsx';
 import { navigationItems } from '../config/navigation.js';
 
+const future = { v7_startTransition: true, v7_relativeSplatPath: true };
+
 afterEach(cleanup);
 
 describe('BottomNavigation', () => {
   it('renders navigation links', () => {
     render(
-      <MemoryRouter>
+      <MemoryRouter future={future}>
         <BottomNavigation items={navigationItems} />
       </MemoryRouter>
     );
@@ -22,7 +24,7 @@ describe('BottomNavigation', () => {
 
   it('wraps links in a nav element with accessibility attributes', () => {
     render(
-      <MemoryRouter>
+      <MemoryRouter future={future}>
         <BottomNavigation items={navigationItems} />
       </MemoryRouter>
     );
@@ -38,7 +40,7 @@ describe('BottomNavigation', () => {
 
   it.each(routes)('marks %s link as active', ({ path, label }) => {
     render(
-      <MemoryRouter initialEntries={[path]}>
+      <MemoryRouter initialEntries={[path]} future={future}>
         <BottomNavigation items={navigationItems} />
       </MemoryRouter>
     );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,7 +7,10 @@ import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter basename={import.meta.env.BASE_URL}>
+    <BrowserRouter
+      basename={import.meta.env.BASE_URL}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
       <StoreProvider>
         <App />
       </StoreProvider>


### PR DESCRIPTION
## Summary
- enable upcoming React Router v7 features to eliminate deprecation warnings
- update tests to use Router future flags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f6ae6601c832cba3fcd238c9405da