### PR TITLE
fix: load source entrypoint during dev

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,17 +2,16 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="./assets/favicon-BWkDtisq.svg" />
+    <link rel="icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RepSmasher</title>
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
       rel="stylesheet"
     />
-    <script type="module" crossorigin src="./assets/index-BF-Gmpjp.js"></script>
-    <link rel="stylesheet" crossorigin href="./assets/index-Cfeztjci.css">
   </head>
   <body class="font-sans bg-white text-gray-900 dark:bg-gray-900 dark:text-white">
     <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure dev server loads Vite source entrypoint instead of built assets
- update favicon link and remove compiled CSS reference

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f72397130832c83ee5942046148c1