### PR TITLE
feat: add ui primitives and workouts icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.23.1"
+    "react-router-dom": "^6.23.1",
+    "lucide-react": "^0.487.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+const variants: Record<string, string> = {
+  default: 'border-transparent bg-primary text-primary-foreground',
+  secondary: 'border-transparent bg-secondary text-secondary-foreground',
+  destructive: 'border-transparent bg-destructive text-white',
+  outline: 'text-foreground',
+};
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: keyof typeof variants;
+}
+
+export function Badge({ className, variant = 'default', ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium',
+        variants[variant],
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { cn } from './utils';
+
+const variants: Record<string, string> = {
+  default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  destructive: 'bg-destructive text-white hover:bg-destructive/90',
+  outline: 'border bg-background hover:bg-accent hover:text-accent-foreground',
+  secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+  ghost: 'hover:bg-accent hover:text-accent-foreground',
+  link: 'text-primary underline-offset-4 hover:underline',
+};
+
+const sizes: Record<string, string> = {
+  default: 'h-9 px-4 py-2',
+  sm: 'h-8 px-3 rounded-md',
+  lg: 'h-10 px-6 rounded-md',
+  icon: 'h-9 w-9',
+};
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof variants;
+  size?: keyof typeof sizes;
+}
+
+export function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={cn(
+        'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50',
+        variants[variant],
+        sizes[size],
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+
+import { cn } from "./utils";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 pt-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <h4
+      data-slot="card-title"
+      className={cn("leading-none", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <p
+      data-slot="card-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6 [&:last-child]:pb-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 pb-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,3 @@
+export * from './card';
+export * from './button';
+export * from './badge';

--- a/src/components/ui/utils.ts
+++ b/src/components/ui/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/src/pages/Workouts.jsx
+++ b/src/pages/Workouts.jsx
@@ -1,6 +1,8 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useStore } from '../store.jsx';
 import { createId } from '../storage.js';
+import { Card, Button, Badge } from '../components/ui';
+import { Dumbbell, Pencil, Copy, Trash2 } from 'lucide-react';
 
 export default function Workouts() {
   const { routines, setRoutines } = useStore();
@@ -28,7 +30,9 @@ export default function Workouts() {
     return (
       <div className="max-w-md mx-auto text-center">
         <p className="text-gray-500 mb-4">No workouts saved.</p>
-        <Link className="text-blue-600" to="/create">Create your first workout</Link>
+        <Button onClick={() => navigate('/create')}>
+          Create your first workout
+        </Button>
       </div>
     );
   }
@@ -36,25 +40,45 @@ export default function Workouts() {
   return (
     <div className="max-w-md mx-auto space-y-4">
       {routines.map(r => (
-        <div
-          key={r.id}
-          className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow"
-        >
+        <Card key={r.id} className="p-4">
           <div
             className="cursor-pointer"
             onClick={() => navigate(`/workout/${r.id}`)}
           >
-            <h3 className="text-lg font-bold">{r.name}</h3>
-            <p className="text-sm text-gray-500">
+            <h3 className="text-lg font-bold flex items-center gap-2">
+              <Dumbbell className="w-4 h-4" /> {r.name}
+            </h3>
+            <Badge variant="secondary" className="mt-1">
               {r.exercises.length} exercise{r.exercises.length !== 1 ? 's' : ''}
-            </p>
+            </Badge>
           </div>
-          <div className="flex justify-end gap-4 mt-4 text-sm">
-            <Link className="text-blue-600" to={`/create?id=${r.id}`}>Edit</Link>
-            <button className="text-blue-600" onClick={() => duplicate(r.id)}>Duplicate</button>
-            <button className="text-red-500" onClick={() => remove(r.id)}>Delete</button>
+          <div className="flex justify-end gap-2 mt-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate(`/create?id=${r.id}`)}
+              aria-label="Edit workout"
+            >
+              <Pencil className="w-4 h-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => duplicate(r.id)}
+              aria-label="Duplicate workout"
+            >
+              <Copy className="w-4 h-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => remove(r.id)}
+              aria-label="Delete workout"
+            >
+              <Trash2 className="w-4 h-4 text-red-500" />
+            </Button>
           </div>
-        </div>
+        </Card>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- add Card, Button, and Badge components with central index
- include lucide-react dependency
- refactor Workouts page to use new UI components and icons

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fe0b20e30832cbb8c104843d01ea4