### PR TITLE
refactor: drop version suffix from design imports

### DIFF
--- a/design/RepSmasher Workout App 8-2-2025/components/ui/accordion.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/accordion.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion@1.2.3";
-import { ChevronDownIcon } from "lucide-react@0.487.0";
+import { ChevronDownIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/breadcrumb.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/breadcrumb.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot@1.1.2";
-import { ChevronRight, MoreHorizontal } from "lucide-react@0.487.0";
+import { ChevronRight, MoreHorizontal } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/calendar.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/calendar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react@0.487.0";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { DayPicker } from "react-day-picker@8.10.1";
 
 import { cn } from "./utils";

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/carousel.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/carousel.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
 } from "embla-carousel-react@8.6.0";
-import { ArrowLeft, ArrowRight } from "lucide-react@0.487.0";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 
 import { cn } from "./utils";
 import { Button } from "./button";

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/checkbox.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox@1.1.4";
-import { CheckIcon } from "lucide-react@0.487.0";
+import { CheckIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/command.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/command.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { Command as CommandPrimitive } from "cmdk@1.1.1";
-import { SearchIcon } from "lucide-react@0.487.0";
+import { SearchIcon } from "lucide-react";
 
 import { cn } from "./utils";
 import {

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/context-menu.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/context-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu@2.2.6";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react@0.487.0";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/dialog.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog@1.1.6";
-import { XIcon } from "lucide-react@0.487.0";
+import { XIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/dropdown-menu.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/dropdown-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu@2.1.6";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react@0.487.0";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/input-otp.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/input-otp.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { OTPInput, OTPInputContext } from "input-otp@1.4.2";
-import { MinusIcon } from "lucide-react@0.487.0";
+import { MinusIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/menubar.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/menubar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as MenubarPrimitive from "@radix-ui/react-menubar@1.1.6";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react@0.487.0";
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/navigation-menu.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu@1.2.5";
 import { cva } from "class-variance-authority@0.7.1";
-import { ChevronDownIcon } from "lucide-react@0.487.0";
+import { ChevronDownIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/pagination.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/pagination.tsx
@@ -3,7 +3,7 @@ import {
   ChevronLeftIcon,
   ChevronRightIcon,
   MoreHorizontalIcon,
-} from "lucide-react@0.487.0";
+} from "lucide-react";
 
 import { cn } from "./utils";
 import { Button, buttonVariants } from "./button";

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/radio-group.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/radio-group.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group@1.2.3";
-import { CircleIcon } from "lucide-react@0.487.0";
+import { CircleIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/resizable.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/resizable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { GripVerticalIcon } from "lucide-react@0.487.0";
+import { GripVerticalIcon } from "lucide-react";
 import * as ResizablePrimitive from "react-resizable-panels@2.1.7";
 
 import { cn } from "./utils";

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/select.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/select.tsx
@@ -6,7 +6,7 @@ import {
   CheckIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-} from "lucide-react@0.487.0";
+} from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/sheet.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/sheet.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog@1.1.6";
-import { XIcon } from "lucide-react@0.487.0";
+import { XIcon } from "lucide-react";
 
 import { cn } from "./utils";
 

--- a/design/RepSmasher Workout App 8-2-2025/components/ui/sidebar.tsx
+++ b/design/RepSmasher Workout App 8-2-2025/components/ui/sidebar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot@1.1.2";
 import { VariantProps, cva } from "class-variance-authority@0.7.1";
-import { PanelLeftIcon } from "lucide-react@0.487.0";
+import { PanelLeftIcon } from "lucide-react";
 
 import { useIsMobile } from "./use-mobile";
 import { cn } from "./utils";


### PR DESCRIPTION
## Summary
- refactor design components to import icons from local `lucide-react`

## Testing
- `npm install lucide-react@0.487.0` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lucide-react)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689012162730832cb65ad7bd82899b19