### PR TITLE
fix: use GH_TOKEN for gh-pages deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "preview": "vite preview --host",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist -r https://github.com/joshbrodeur/RepSmasher.git",
+    "deploy": "gh-pages -d dist -r https://x-access-token:${GH_TOKEN}@github.com/joshbrodeur/RepSmasher.git",
     "test": "vitest run"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- ensure gh-pages uses GitHub Actions token for authentication

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890bff0565c832cad23cf26b86baa7b