### PR TITLE
fix(ci): enable gh-pages deploy with write token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -35,5 +38,5 @@ jobs:
       - name: Deploy to GitHub Pages
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: npm run deploy


### PR DESCRIPTION
## Summary
- grant workflow `contents: write` permission for deployment
- use `GH_TOKEN` secret during GitHub Pages deploy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c184c0dc832cb75eca2d596f8759