### PR TITLE
Handle storage errors

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -1,10 +1,20 @@
 export function load(key, def) {
-  const data = localStorage.getItem(key);
-  return data ? JSON.parse(data) : def;
+  try {
+    const data = localStorage.getItem(key);
+    return data ? JSON.parse(data) : def;
+  } catch (err) {
+    console.error('Failed to load from storage', err);
+    return def;
+  }
 }
 
 export function save(key, val) {
-  localStorage.setItem(key, JSON.stringify(val));
+  try {
+    localStorage.setItem(key, JSON.stringify(val));
+  } catch (err) {
+    console.error('Failed to save to storage', err);
+    throw err;
+  }
 }
 
 export function createId() {

--- a/src/storage.test.js
+++ b/src/storage.test.js
@@ -17,6 +17,26 @@ describe('storage utilities', () => {
     expect(load('key', null)).toEqual(data);
   });
 
+  it('returns default when stored JSON is invalid', () => {
+    localStorage.setItem('bad', '{');
+    expect(load('bad', 'fallback')).toBe('fallback');
+  });
+
+  it('returns default when storage throws', () => {
+    const original = localStorage.getItem;
+    localStorage.getItem = () => {
+      throw new Error('failed');
+    };
+    expect(load('any', 'fallback')).toBe('fallback');
+    localStorage.getItem = original;
+  });
+
+  it('save surfaces JSON errors', () => {
+    const obj = {};
+    obj.self = obj;
+    expect(() => save('x', obj)).toThrow();
+  });
+
   it('createId generates unique strings', () => {
     const id1 = createId();
     const id2 = createId();


### PR DESCRIPTION
## Summary
- Guard storage load/save operations with try/catch to handle failures
- Add tests for error conditions in storage utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891145bde74832cab9e2871191b1518