### PR TITLE
test: add workout and create-workout tests

### DIFF
--- a/src/pages/CreateWorkout.test.jsx
+++ b/src/pages/CreateWorkout.test.jsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import CreateWorkout from './CreateWorkout.jsx';
+
+const future = { v7_startTransition: true, v7_relativeSplatPath: true };
+
+let mockStore;
+vi.mock('../store.jsx', () => ({
+  useStore: () => mockStore,
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockStore = {
+    routines: [],
+    setRoutines: vi.fn(fn => {
+      mockStore.routines = typeof fn === 'function' ? fn(mockStore.routines) : fn;
+    }),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe('CreateWorkout page', () => {
+  it('autosaves changes and navigates home on done', async () => {
+    render(
+      <MemoryRouter initialEntries={['/create']} future={future}>
+        <Routes>
+          <Route path="/create" element={<CreateWorkout />} />
+          <Route path="/" element={<div>Home Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/workout name/i), {
+      target: { value: 'Leg Day' },
+    });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(mockStore.routines).toHaveLength(1);
+    expect(mockStore.routines[0]).toMatchObject({ name: 'Leg Day' });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(/done/i));
+    });
+
+    expect(screen.getByText(/home page/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/Workout.test.jsx
+++ b/src/pages/Workout.test.jsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Workout from './Workout.jsx';
+
+const future = { v7_startTransition: true, v7_relativeSplatPath: true };
+
+let mockStore;
+vi.mock('../store.jsx', () => ({
+  useStore: () => mockStore,
+}));
+
+beforeEach(() => {
+  mockStore = {
+    routines: [
+      {
+        id: 'r1',
+        name: 'Test Routine',
+        exercises: [{ type: 'Push Ups', reps: 0, weight: 0 }],
+      },
+    ],
+    workouts: [],
+    setWorkouts: vi.fn(w => {
+      mockStore.workouts = w;
+    }),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('Workout page', () => {
+  it('saves records and navigates to summary when workout is finished', async () => {
+    render(
+      <MemoryRouter initialEntries={['/workout/r1']} future={future}>
+        <Routes>
+          <Route path="/workout/:id" element={<Workout />} />
+          <Route path="/summary/:id" element={<div>Summary Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText(/start workout/i));
+    fireEvent.click(screen.getByText(/done/i));
+
+    await screen.findByText(/summary page/i);
+
+    expect(mockStore.workouts).toHaveLength(1);
+    expect(mockStore.workouts[0].records[0]).toMatchObject({ type: 'Push Ups' });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for workout start and finish flow, ensuring saved records and summary navigation
- cover create workout autosave and done navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68912799d318832c8a3d9381d22cc70a