### PR TITLE
Add stats button to workouts page and filter logs

### DIFF
--- a/src/pages/Logs.jsx
+++ b/src/pages/Logs.jsx
@@ -1,23 +1,31 @@
 import { useStore } from '../store.jsx';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 export default function Logs() {
   const { workouts, routines } = useStore();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const routineId = searchParams.get('routine');
 
   const counts = {};
+  const filteredLogs = workouts
+    .map((log, idx) => ({ log, idx }))
+    .filter(({ log }) => !routineId || log.routineId === routineId);
 
   return (
     <div className="max-w-md mx-auto">
       <ul className="space-y-2">
-        {workouts.map((log, idx) => {
+        {filteredLogs.map(({ log, idx }) => {
           counts[log.routineId] = (counts[log.routineId] || 0) + 1;
           const count = counts[log.routineId];
           const routine = routines.find(r => r.id === log.routineId) || { name: 'Workout' };
           const date = new Date(log.date);
           return (
             <li key={idx} className="bg-white dark:bg-gray-800 p-3 rounded shadow">
-              <span className="cursor-pointer" onClick={() => navigate(`/summary/${idx}`)}>
+              <span
+                className="cursor-pointer"
+                onClick={() => navigate(`/summary/${idx}`)}
+              >
                 {routine.name} - #{count} - {date.toLocaleString()}
               </span>
             </li>

--- a/src/pages/Workouts.jsx
+++ b/src/pages/Workouts.jsx
@@ -8,6 +8,7 @@ import {
   Copy,
   Trash2,
   Play,
+  Eye,
   Clock,
   Hash,
 } from 'lucide-react';
@@ -131,13 +132,20 @@ export default function Workouts() {
               </div>
             </div>
 
-            <div className="flex mt-2">
+            <div className="flex gap-2 mt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate(`/logs?routine=${r.id}`)}
+              >
+                <Eye className="w-4 h-4 mr-2" /> View Stats
+              </Button>
               <Button
                 size="sm"
                 onClick={() => navigate(`/workout/${r.id}`)}
                 className="bg-green-500 hover:bg-green-600 text-white"
               >
-                <Play className="w-4 h-4" /> Start
+                <Play className="w-4 h-4 mr-2" /> Start
               </Button>
             </div>
           </Card>


### PR DESCRIPTION
## Summary
- add View Stats button on each workout card
- allow viewing logs filtered by routine via query parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689130273630832cbb17ea5ca06ce4f8