### PR TITLE
fix: prevent duplicate routine spamming

### DIFF
--- a/src/pages/Workouts.jsx
+++ b/src/pages/Workouts.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+import { useState, useRef } from 'react';
 import { useStore } from '../store.jsx';
 import { createId } from '../storage.js';
 import { Card, Button } from '../components/ui';
@@ -16,6 +17,8 @@ import {
 export default function Workouts() {
   const { routines, setRoutines, workouts } = useStore();
   const navigate = useNavigate();
+  const [isDuplicating, setIsDuplicating] = useState(false);
+  const isDuplicatingRef = useRef(false);
 
   function remove(id) {
     if (confirm('Delete this routine?')) {
@@ -24,15 +27,29 @@ export default function Workouts() {
   }
 
   function duplicate(id) {
+    if (isDuplicatingRef.current) return;
+    isDuplicatingRef.current = true;
+    setIsDuplicating(true);
+
     const routine = routines.find(r => r.id === id);
-    if (!routine) return;
+    if (!routine) {
+      isDuplicatingRef.current = false;
+      setIsDuplicating(false);
+      return;
+    }
+
     const copy = {
       ...routine,
       id: createId(),
       name: routine.name + ' Copy',
       exercises: routine.exercises.map(ex => ({ ...ex, id: createId() })),
     };
-    setRoutines([...routines, copy]);
+    setRoutines(prev => [...prev, copy]);
+
+    setTimeout(() => {
+      isDuplicatingRef.current = false;
+      setIsDuplicating(false);
+    }, 0);
   }
 
   if (routines.length === 0) {
@@ -94,6 +111,7 @@ export default function Workouts() {
                   size="sm"
                   onClick={() => duplicate(r.id)}
                   aria-label="Duplicate workout"
+                  disabled={isDuplicating}
                 >
                   <Copy className="w-4 h-4" />
                 </Button>

--- a/src/pages/Workouts.test.jsx
+++ b/src/pages/Workouts.test.jsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { MemoryRouter } from 'react-router-dom';
+import Workouts from './Workouts.jsx';
+
+const future = { v7_startTransition: true, v7_relativeSplatPath: true };
+
+let mockStore;
+vi.mock('../store.jsx', () => ({
+  useStore: () => mockStore,
+}));
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockStore = {
+    routines: [
+      {
+        id: 'r1',
+        name: 'Test Routine',
+        exercises: [{ type: 'Push Ups', reps: 0, weight: 0, id: 'e1' }],
+      },
+    ],
+    workouts: [],
+    setRoutines: vi.fn(fn => {
+      mockStore.routines = typeof fn === 'function' ? fn(mockStore.routines) : fn;
+    }),
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe('Workouts page', () => {
+  it('only duplicates once on rapid clicks', () => {
+    render(
+      <MemoryRouter future={future}>
+        <Workouts />
+      </MemoryRouter>
+    );
+
+    const dupBtn = screen.getByLabelText(/duplicate workout/i);
+
+    fireEvent.click(dupBtn);
+    fireEvent.click(dupBtn);
+
+    vi.runAllTimers();
+
+    expect(mockStore.routines).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- guard duplicate routine logic against rapid clicks and use functional state updates
- add test for duplicate routine edge case

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68920a147128832c92c83e624c162aec