### PR TITLE
fix: prevent duplicate routine autosaves

### DIFF
--- a/src/pages/CreateWorkout.jsx
+++ b/src/pages/CreateWorkout.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useStore } from '../store.jsx';
 import { createId } from '../storage.js';
@@ -10,7 +10,7 @@ export default function CreateWorkout() {
   const editId = searchParams.get('id');
 
   const existing = routines.find(r => r.id === editId);
-  const routineId = existing ? existing.id : createId();
+  const routineIdRef = useRef(existing ? existing.id : createId());
   const [name, setName] = useState(existing?.name || '');
   const [exercises, setExercises] = useState(() => existing ? [...existing.exercises] : []);
   const [saveStatus, setSaveStatus] = useState('saved');
@@ -68,11 +68,11 @@ export default function CreateWorkout() {
   }
 
   const saveRoutine = useCallback(() => {
-    const routine = { id: routineId, name: name || 'Routine', exercises };
+    const routine = { id: routineIdRef.current, name: name || 'Routine', exercises };
     try {
       setRoutines(prev => {
-        const list = prev.some(r => r.id === routineId)
-          ? prev.map(r => (r.id === routineId ? routine : r))
+        const list = prev.some(r => r.id === routineIdRef.current)
+          ? prev.map(r => (r.id === routineIdRef.current ? routine : r))
           : [...prev, routine];
         return list;
       });
@@ -80,7 +80,7 @@ export default function CreateWorkout() {
     } catch {
       setSaveStatus('error');
     }
-  }, [routineId, name, exercises, setRoutines]);
+  }, [name, exercises, setRoutines]);
 
   useEffect(() => {
     setSaveStatus('saving');

--- a/src/pages/CreateWorkout.test.jsx
+++ b/src/pages/CreateWorkout.test.jsx
@@ -55,4 +55,33 @@ describe('CreateWorkout page', () => {
 
     expect(screen.getByText(/home page/i)).toBeInTheDocument();
   });
+
+  it('does not create duplicate routines on multiple autosaves', async () => {
+    render(
+      <MemoryRouter initialEntries={['/create']} future={future}>
+        <Routes>
+          <Route path="/create" element={<CreateWorkout />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Allow initial autosave to run
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(mockStore.routines).toHaveLength(1);
+    expect(mockStore.routines[0]).toMatchObject({ name: 'Routine' });
+
+    fireEvent.change(screen.getByPlaceholderText(/workout name/i), {
+      target: { value: 'Leg Day' },
+    });
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    expect(mockStore.routines).toHaveLength(1);
+    expect(mockStore.routines[0]).toMatchObject({ name: 'Leg Day' });
+  });
 });


### PR DESCRIPTION
## Summary
- prevent new workout pages from generating new IDs on each render
- add regression test guarding against duplicate routines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689403a75864832cbe86435b29b2e6f4