### PR TITLE
feat: track sets by name and remember exercise names

### DIFF
--- a/src/pages/CreateWorkout.jsx
+++ b/src/pages/CreateWorkout.jsx
@@ -4,7 +4,7 @@ import { useStore } from '../store.jsx';
 import { createId } from '../storage.js';
 
 export default function CreateWorkout() {
-  const { routines, setRoutines } = useStore();
+  const { routines, setRoutines, exerciseNames, setExerciseNames } = useStore();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const editId = searchParams.get('id');
@@ -16,14 +16,14 @@ export default function CreateWorkout() {
   function addExercise() {
     setExercises([
       ...exercises,
-      { id: createId(), type: '', sets: 1, reps: 0, weight: 0, rest: 0 }
+      { id: createId(), type: '', eng: 0, reps: 0, weight: 0, rest: 0 }
     ]);
   }
 
   function addRest() {
     setExercises([
       ...exercises,
-      { id: createId(), type: 'Rest', sets: 1, reps: 0, weight: 0, rest: 30, restSet: true }
+      { id: createId(), type: 'Rest', eng: 0, reps: 0, weight: 0, rest: 30, restSet: true }
     ]);
   }
 
@@ -85,6 +85,11 @@ export default function CreateWorkout() {
     const workoutName = window.prompt('Enter workout name', existing?.name || '');
     if (!workoutName) return;
     saveRoutine(workoutName);
+    const names = new Set(exerciseNames);
+    exercises.forEach(ex => {
+      if (ex.type && ex.type !== 'Rest') names.add(ex.type);
+    });
+    setExerciseNames(Array.from(names));
     navigate('/');
   }
 
@@ -93,6 +98,11 @@ export default function CreateWorkout() {
       <h2 className="text-lg font-bold text-center">
         {existing ? 'Edit Workout' : 'Create Workout'}
       </h2>
+      <datalist id="exercise-options">
+        {exerciseNames.map(name => (
+          <option key={name} value={name} />
+        ))}
+      </datalist>
       <div className="flex gap-2">
         <button className="flex-1 p-2 bg-blue-600 text-white rounded" onClick={addExercise}>
           Add Exercise
@@ -126,6 +136,7 @@ export default function CreateWorkout() {
                 <div>
                   <label className="block text-sm mb-1">Exercise</label>
                   <input
+                    list="exercise-options"
                     className="w-full p-2 rounded border dark:bg-gray-700"
                     value={ex.type}
                     onChange={e => updateExercise(idx, 'type', e.target.value)}
@@ -133,12 +144,12 @@ export default function CreateWorkout() {
                 </div>
                 <div className="grid grid-cols-3 gap-2">
                   <div>
-                    <label className="block text-sm mb-1">Sets</label>
+                    <label className="block text-sm mb-1">Eng</label>
                     <input
                       type="number"
                       className="w-full p-2 rounded border dark:bg-gray-700"
-                      value={ex.sets}
-                      onChange={e => updateExercise(idx, 'sets', parseInt(e.target.value, 10) || 0)}
+                      value={ex.eng}
+                      onChange={e => updateExercise(idx, 'eng', parseInt(e.target.value, 10) || 0)}
                     />
                   </div>
                   <div>

--- a/src/pages/CreateWorkout.test.jsx
+++ b/src/pages/CreateWorkout.test.jsx
@@ -17,6 +17,10 @@ beforeEach(() => {
     setRoutines: vi.fn(fn => {
       mockStore.routines = typeof fn === 'function' ? fn(mockStore.routines) : fn;
     }),
+    exerciseNames: [],
+    setExerciseNames: vi.fn(fn => {
+      mockStore.exerciseNames = typeof fn === 'function' ? fn(mockStore.exerciseNames) : fn;
+    }),
   };
 });
 
@@ -71,5 +75,26 @@ describe('CreateWorkout page', () => {
 
     expect(mockStore.routines).toHaveLength(1);
     expect(mockStore.routines[0]).toMatchObject({ name: 'Leg Day' });
+  });
+
+  it('stores exercise names for autocomplete', async () => {
+    render(
+      <MemoryRouter initialEntries={['/create']} future={future}>
+        <Routes>
+          <Route path="/create" element={<CreateWorkout />} />
+          <Route path="/" element={<div />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByText(/add exercise/i));
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Push Ups' } });
+
+    vi.spyOn(window, 'prompt').mockReturnValue('Chest Day');
+    await act(async () => {
+      fireEvent.click(screen.getByText(/done/i));
+    });
+
+    expect(mockStore.exerciseNames).toContain('Push Ups');
   });
 });

--- a/src/pages/Summary.jsx
+++ b/src/pages/Summary.jsx
@@ -14,12 +14,26 @@ export default function Summary() {
     .filter(r => r.type === 'Rest')
     .reduce((sum, r) => sum + (r.end - r.start), 0);
 
+  const exerciseStats = log.records
+    .filter(r => r.type !== 'Rest')
+    .reduce((acc, r) => {
+      if (!acc[r.type]) acc[r.type] = { sets: 0, totalReps: 0 };
+      acc[r.type].sets += 1;
+      acc[r.type].totalReps += r.reps;
+      return acc;
+    }, {});
+
   return (
     <div className="max-w-md mx-auto space-y-4">
       <h2 className="text-lg font-bold text-center">{routine.name}</h2>
       <div className="bg-white dark:bg-gray-800 p-4 rounded shadow space-y-2">
         <p>Total time: {(log.totalTime / 1000).toFixed(1)}s</p>
         <p>Total rest: {(totalRest / 1000).toFixed(0)}s</p>
+        {Object.entries(exerciseStats).map(([name, stat]) => (
+          <div key={name}>
+            {name}: {stat.sets} sets avg {(stat.totalReps / stat.sets).toFixed(1)} reps
+          </div>
+        ))}
         {log.records.map((r, i) => (
           <div key={i}>
             {r.type === 'Rest'

--- a/src/store.jsx
+++ b/src/store.jsx
@@ -6,12 +6,14 @@ const StoreContext = createContext();
 export function StoreProvider({ children }) {
   const [routines, setRoutines] = useState(() => load('routines', []));
   const [workouts, setWorkouts] = useState(() => load('workouts', []));
+  const [exerciseNames, setExerciseNames] = useState(() => load('exerciseNames', []));
 
   useEffect(() => save('routines', routines), [routines]);
   useEffect(() => save('workouts', workouts), [workouts]);
+  useEffect(() => save('exerciseNames', exerciseNames), [exerciseNames]);
 
   return (
-    <StoreContext.Provider value={{ routines, setRoutines, workouts, setWorkouts }}>
+    <StoreContext.Provider value={{ routines, setRoutines, workouts, setWorkouts, exerciseNames, setExerciseNames }}>
       {children}
     </StoreContext.Provider>
   );


### PR DESCRIPTION
## Summary
- replace exercise "Sets" input with an energy field and autocomplete
- persist exercise names so future workouts can reuse them
- group duplicate exercise names in workout summaries to show set counts and average reps

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68940bbf2f9c832c9186504eecc327c6