### PR TITLE
test: ensure editing incomplete exercises warning-free

### DIFF
--- a/src/pages/CreateWorkout.test.jsx
+++ b/src/pages/CreateWorkout.test.jsx
@@ -97,4 +97,31 @@ describe('CreateWorkout page', () => {
 
     expect(mockStore.exerciseNames).toContain('Push Ups');
   });
+
+  it('edits existing routine with missing fields without warnings', async () => {
+    mockStore.routines = [
+      {
+        id: '1',
+        name: 'Old Routine',
+        exercises: [{ type: 'Push Ups' }]
+      }
+    ];
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <MemoryRouter initialEntries={['/create?id=1']} future={future}>
+        <Routes>
+          <Route path="/create" element={<CreateWorkout />} />
+          <Route path="/" element={<div />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      fireEvent.change(screen.getByRole('combobox'), { target: { value: 'Pull Ups' } });
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- add regression test for editing routines with incomplete exercises

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689411e1b90c832ca1e1714498369427